### PR TITLE
Update broken install.sh gmp link

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,7 @@ then
 
     if [ ! -f gmp-5.0.5.tar.bz2 ];
     then
-        $get ftp://ftp.gmplib.org/pub/gmp-5.0.5/gmp-5.0.5.tar.bz2
+        $get ftp://ftp.gnu.org/gnu/gmp/gmp-5.0.5.tar.bz2
     fi
 
     sum=`openssl sha1 gmp-5.0.5.tar.bz2 | awk -F' ' '{print $2}'`


### PR DESCRIPTION
Old link seemed to be broken, switched to new ftp url from gmp website.