### PR TITLE
Fix install.sh to build on modern (2025) Linux

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,7 @@ then
 
     if [ ! -f gmp-5.0.5.tar.bz2 ];
     then
-        $get ftp://ftp.gmplib.org/pub/gmp-5.0.5/gmp-5.0.5.tar.bz2
+        $get ftp://ftp.gnu.org/gnu/gmp/gmp-5.0.5.tar.bz2
     fi
 
     sum=`openssl sha1 gmp-5.0.5.tar.bz2 | awk -F' ' '{print $2}'`
@@ -33,6 +33,7 @@ fi
 cd gmp-5.0.5
 patch -p 1 < ../gmp-5.0.5.patch
 mkdir ../gmp-patched
+export CC=gcc-4.9
 ./configure --prefix=$PWD/../gmp-patched/
 make
 make install


### PR DESCRIPTION
- This updates the gmplib download url to one that still exists (the other PR does this too, I think)

- And it adds CC=gcc-4.9 so it actually builds, modern gcc versions are so strict that they throw errors on some of the things ./configure checks (long long support) but for other reason than ./configure thinks so it gives very misleading error messages. This makes sure an ancient enough gcc is used